### PR TITLE
修正SAR加速因子AF初始值

### DIFF
--- a/umychart_indexapi/jscommon/umychart.node.js
+++ b/umychart_indexapi/jscommon/umychart.node.js
@@ -43847,7 +43847,7 @@ function JSAlgorithm(errorHandler,symbolData)
         const SAR_LONG=0, SAR_SHORT=1;
         var position=SAR_LONG;
         result[n-1]=low;
-        var nextSar=low, sip=stockData.Data[0].High,af=exValue/100;
+        var nextSar=low, sip=stockData.Data[0].High,af=step/100;
         for(var i=n;i<stockData.Data.length;++i)
         {
             var ysip=sip;

--- a/umychart_python/umychart_complier_jsalgorithm.py
+++ b/umychart_python/umychart_complier_jsalgorithm.py
@@ -2226,7 +2226,7 @@ class JSAlgorithm() :
         result[n-1]=low
         nextSar=low
         sip=stockData.Data[0].High
-        af=exValue/100
+        af=step/100
         for i in range(n,dataLen) :
             ysip=sip
             item=stockData.Data[i]

--- a/umychart_uniapp_h5/umychart.uniapp.h5.js
+++ b/umychart_uniapp_h5/umychart.uniapp.h5.js
@@ -43894,7 +43894,7 @@ function JSAlgorithm(errorHandler,symbolData)
         const SAR_LONG=0, SAR_SHORT=1;
         var position=SAR_LONG;
         result[n-1]=low;
-        var nextSar=low, sip=stockData.Data[0].High,af=exValue/100;
+        var nextSar=low, sip=stockData.Data[0].High,af=step/100;
         for(var i=n;i<stockData.Data.length;++i)
         {
             var ysip=sip;

--- a/vuehqchart/src/jscommon/umychart.complier.js
+++ b/vuehqchart/src/jscommon/umychart.complier.js
@@ -4807,7 +4807,7 @@ function JSAlgorithm(errorHandler,symbolData)
         const SAR_LONG=0, SAR_SHORT=1;
         var position=SAR_LONG;
         result[n-1]=low;
-        var nextSar=low, sip=stockData.Data[0].High,af=exValue/100;
+        var nextSar=low, sip=stockData.Data[0].High,af=step/100;
         for(var i=n;i<stockData.Data.length;++i)
         {
             var ysip=sip;

--- a/vuehqchart/src/jscommon/umychart.vue/umychart.vue.js
+++ b/vuehqchart/src/jscommon/umychart.vue/umychart.vue.js
@@ -43935,7 +43935,7 @@ function JSAlgorithm(errorHandler,symbolData)
         const SAR_LONG=0, SAR_SHORT=1;
         var position=SAR_LONG;
         result[n-1]=low;
-        var nextSar=low, sip=stockData.Data[0].High,af=exValue/100;
+        var nextSar=low, sip=stockData.Data[0].High,af=step/100;
         for(var i=n;i<stockData.Data.length;++i)
         {
             var ysip=sip;

--- a/webhqchart.demo/jscommon/umychart.complier.js
+++ b/webhqchart.demo/jscommon/umychart.complier.js
@@ -4807,7 +4807,7 @@ function JSAlgorithm(errorHandler,symbolData)
         const SAR_LONG=0, SAR_SHORT=1;
         var position=SAR_LONG;
         result[n-1]=low;
-        var nextSar=low, sip=stockData.Data[0].High,af=exValue/100;
+        var nextSar=low, sip=stockData.Data[0].High,af=step/100;
         for(var i=n;i<stockData.Data.length;++i)
         {
             var ysip=sip;

--- a/webhqchart/umychart.complier.js
+++ b/webhqchart/umychart.complier.js
@@ -4807,7 +4807,7 @@ function JSAlgorithm(errorHandler,symbolData)
         const SAR_LONG=0, SAR_SHORT=1;
         var position=SAR_LONG;
         result[n-1]=low;
-        var nextSar=low, sip=stockData.Data[0].High,af=exValue/100;
+        var nextSar=low, sip=stockData.Data[0].High,af=step/100;
         for(var i=n;i<stockData.Data.length;++i)
         {
             var ysip=sip;


### PR DESCRIPTION
根据
https://wiki.mbalib.com/wiki/%E6%8A%9B%E7%89%A9%E7%BA%BF%E8%BD%AC%E5%90%91
SAR抛物线转向中AF的初始值应为步长,非极值